### PR TITLE
visible - inherit this from HtmlTemplate

### DIFF
--- a/client_code/Components/Checkbox/__init__.py
+++ b/client_code/Components/Checkbox/__init__.py
@@ -1,6 +1,7 @@
 from ._anvil_designer import CheckboxTemplate
 from anvil import *
-from ...Functions import enabled_property, style_property, visible_property, underline_property, italic_property, bold_property, font_size_property, color_property, theme_color_to_css, innerText_property
+from anvil import HtmlTemplate
+from ...Functions import enabled_property, style_property, underline_property, italic_property, bold_property, font_size_property, color_property, theme_color_to_css, innerText_property
 import anvil.designer
 
 
@@ -52,7 +53,7 @@ class Checkbox(CheckboxTemplate):
       self.raise_event("click")
 
   enabled = enabled_property('anvil-m3-checkbox')
-  visible = visible_property('anvil-m3-checkbox-container', 'inline-flex')
+  visible = HtmlTemplate.visible
   underline = underline_property('anvil-m3-checkbox-label')
   italic = italic_property('anvil-m3-checkbox-label')
   bold = bold_property('anvil-m3-checkbox-label')

--- a/client_code/Components/Heading/__init__.py
+++ b/client_code/Components/Heading/__init__.py
@@ -1,7 +1,8 @@
 from ._anvil_designer import HeadingTemplate
 from anvil import *
+from anvil import HtmlTemplate
 import anvil.designer
-from ...Functions import visible_property, underline_property, italic_property, style_property, color_property, innerText_property, bold_property, font_size_property
+from ...Functions import underline_property, italic_property, style_property, color_property, innerText_property, bold_property, font_size_property
 
 #TODO: figure out what to do with line height
 #TODO: add margin and padding
@@ -29,7 +30,7 @@ class Heading(HeadingTemplate):
     }]
     return di
 
-  visible = visible_property('anvil-m3-heading-container', 'flex')
+  visible = HtmlTemplate.visible
   italic = italic_property('anvil-m3-heading-container')
   border = style_property('anvil-m3-heading-container', 'border')
   font = style_property('anvil-m3-heading-container', 'fontFamily')

--- a/client_code/Components/RadioButton/__init__.py
+++ b/client_code/Components/RadioButton/__init__.py
@@ -1,8 +1,9 @@
 from ._anvil_designer import RadioButtonTemplate
 from anvil import *
+from anvil import HtmlTemplate
 from anvil.js.window import document
 import anvil.designer
-from ...Functions import checked_property, name_property, innerText_property, enabled_property, style_property, visible_property, underline_property, italic_property, bold_property, font_size_property, color_property, theme_color_to_css, value_property
+from ...Functions import checked_property, name_property, innerText_property, enabled_property, style_property, underline_property, italic_property, bold_property, font_size_property, color_property, theme_color_to_css, value_property
 
 class RadioButton(RadioButtonTemplate):
   def __init__(self, **properties):
@@ -11,7 +12,7 @@ class RadioButton(RadioButtonTemplate):
     self.dom_nodes['anvil-m3-radiobutton-hover'].addEventListener("click", self.handle_click)
 
   # Properties 
-  visible = visible_property('anvil-m3-radiobutton-container', 'inline-flex')
+  visible = HtmlTemplate.visible
   group_name = name_property('anvil-m3-radiobutton-input')
   value = value_property('anvil-m3-radiobutton-input')
   enabled = enabled_property('anvil-m3-radiobutton-input')

--- a/client_code/Components/Text/__init__.py
+++ b/client_code/Components/Text/__init__.py
@@ -1,7 +1,8 @@
 from ._anvil_designer import TextTemplate
 from anvil import *
+from anvil import HtmlTemplate
 import anvil.designer
-from ...Functions import visible_property, underline_property, italic_property, style_property, color_property, innerText_property, bold_property, font_size_property
+from ...Functions import underline_property, italic_property, style_property, color_property, innerText_property, bold_property, font_size_property
 
 #TODO: figure out what to do with line height
 #TODO: add margin and padding
@@ -30,7 +31,7 @@ class Text(TextTemplate):
     }]
     return di
 
-  visible = visible_property('anvil-m3-text-container', 'flex')
+  visible = HtmlTemplate.visible
   underline = underline_property('anvil-m3-text')
   italic = italic_property('anvil-m3-text')
   bold = bold_property('anvil-m3-text')

--- a/client_code/Functions.py
+++ b/client_code/Functions.py
@@ -97,19 +97,6 @@ def value_property(dom_node_name):
 
   return property(getter, setter)
 
-def visible_property(dom_node_name, display_prop):
-  def getter(self):
-    return self._visible
-
-  def setter(self, value):
-    self._visible = value
-    if value:
-      self.dom_nodes[dom_node_name].style.display = display_prop
-    else:
-      self.dom_nodes[dom_node_name].style.display = 'none'
-
-  return property(getter, setter)
-
 def underline_property(dom_node_name):
   def getter(self):
     return self._underline


### PR DESCRIPTION
since all M3 custom components are `HtmlTemplates` we can inherit our visible property from there
this means that visible will behave like it does for native components

side note 
I used a named import and we might want to remove `from anvil import *` everywhere
just because it's generally frowned upon